### PR TITLE
Fix pfunit path in CI and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Build project
         run: make
         env:
-          PFUNIT: $HOME/pfunit
+          PFUNIT: ${{ env.HOME }}/pfunit
       - name: Run tests
         run: make check
         env:
-          PFUNIT: $HOME/pfunit
+          PFUNIT: ${{ env.HOME }}/pfunit

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ make
 ./calc
 ```
 
-Run tests:
+Run tests (requires pFUnit):
 
 ```bash
-export PFUNIT=/opt/pfunit
+export PFUNIT=$HOME/pfunit  # adjust if pFUnit is installed elsewhere
 make check
 ```
 


### PR DESCRIPTION
## Summary
- update README instructions for pFUnit path
- fix CI to set PFUNIT using `${{ env.HOME }}`

## Testing
- `make clean && make`
- `make check` *(fails: /opt/pfunit missing)*