### PR TITLE
Fix pFUnit compiler script path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ calc: $(OBJ)
 build/tests:
 	@mkdir -p build/tests
 
+
 check: all build/tests tests/test_float_ops.pf
-	$(PFUNIT)/bin/pfunit-compile tests/test_float_ops.pf -o build/tests/test_float_ops
+	$(PFUNIT)/bin/pFUnit-compile tests/test_float_ops.pf -o build/tests/test_float_ops
 	build/tests/test_float_ops
 
 clean:


### PR DESCRIPTION
## Summary
- use `pFUnit-compile` script for tests

## Testing
- `make clean`
- `make check` *(fails: `/opt/pfunit/bin/pFUnit-compile` missing)*