### PR TITLE
Improve README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,25 @@ make
 
 Run tests:
 
+pFUnit usually installs to `~/pfunit` after you run `make install` in the
+pFUnit source directory. The Makefile looks for pFUnit using the environment
+variable `PFUNIT` (default is `/opt/pfunit`). If you installed pFUnit
+elsewhere, override this variable accordingly:
+
 ```bash
-export PFUNIT=/opt/pfunit
+export PFUNIT=~/pfunit  # adjust if your installation lives somewhere else
+```
+
+Before running the tests, verify that `pfunit-compile` exists under
+`$PFUNIT/bin`:
+
+```bash
+ls $PFUNIT/bin/pfunit-compile
+```
+
+Then execute the test suite:
+
+```bash
 make check
 ```
 


### PR DESCRIPTION
## Summary
- explain where pFUnit installs and how to override the `PFUNIT` variable
- show how to verify `pfunit-compile` and run tests

## Testing
- `make check` *(fails: /opt/pfunit/bin/pfunit-compile: No such file or directory)*