### PR TITLE
Update PFUNIT default path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 FC = gfortran
 FFLAGS = -Wall -O2 -Jbuild
-PFUNIT ?= /opt/pfunit
+# Default path for pFUnit; override PFUNIT to match your installation
+PFUNIT ?= $(HOME)/pfunit
 
 SRC = src/float_ops.f90 src/main.f90
 OBJ = $(SRC:.f90=.o)


### PR DESCRIPTION
## Summary
- set default PFUNIT location to `$(HOME)/pfunit`
- clarify that PFUNIT can be overridden in Makefile

## Testing
- `make check` *(fails: `/root/pfunit/bin/pfunit-compile: No such file or directory`)*